### PR TITLE
refactor: 답변 목록 조회 시 페이지네이션 메타 정보 반환 추가

### DIFF
--- a/src/global/common/pagable-meta.ts
+++ b/src/global/common/pagable-meta.ts
@@ -1,0 +1,15 @@
+export class PagableMeta {
+    readonly totalItems: number;
+    readonly itemCount: number;
+    readonly itemsPerPage: number;
+    readonly totalPages: number;
+    readonly currentPage: number;
+
+    constructor(total: number, count: number, offset: number, limit: number) {
+        this.totalItems = total;
+        this.itemCount = count;
+        this.itemsPerPage = limit;
+        this.totalPages = Math.ceil(total / limit);
+        this.currentPage = Math.floor(offset / limit) + 1;
+    }
+}

--- a/src/modules/calendar/calendar.service.ts
+++ b/src/modules/calendar/calendar.service.ts
@@ -16,6 +16,7 @@ import {
 } from '../../global/exception/custom.exception';
 import { QuestionRepository } from '../question/repository/question.repository';
 import { GetAnswerPagableResponse } from './dto/response/get.answer-pagable.response';
+import { PagableMeta } from '../../global/common/pagable-meta';
 
 @Injectable()
 export class CalendarService {
@@ -65,12 +66,17 @@ export class CalendarService {
         request: GetAnswerRequest,
     ): Promise<GetAnswerPagableResponse> {
         const answers = await this.calendarRepository.getAllAnswers(request);
-        // hasNext 값 계산 (limit보다 데이터가 많으면 다음 페이지 존재)
-        const hasNext = answers.length > (request.limit || 10);
-        const answersResponse = answers
-            .slice(0, request.limit || 10)
-            .map((answer) => new GetAnswerResponse(answer));
-        return new GetAnswerPagableResponse(hasNext, answersResponse);
+        const items = answers.items.map(
+            (answer) => new GetAnswerResponse(answer),
+        );
+        // 메타 정보 생성
+        const meta = new PagableMeta(
+            answers.total,
+            answers.items.length,
+            request.offset,
+            request.limit,
+        );
+        return new GetAnswerPagableResponse(items, meta);
     }
 
     // 답변 개수 조회

--- a/src/modules/calendar/dto/response/get.answer-pagable.response.ts
+++ b/src/modules/calendar/dto/response/get.answer-pagable.response.ts
@@ -1,11 +1,12 @@
 import { GetAnswerResponse } from './get.answer.response';
+import { PagableMeta } from '../../../../global/common/pagable-meta';
 
 export class GetAnswerPagableResponse {
-    readonly hasNext: boolean;
     readonly answers: GetAnswerResponse[];
+    readonly meta: PagableMeta;
 
-    constructor(hasNext: boolean, answers: GetAnswerResponse[]) {
-        this.hasNext = hasNext;
+    constructor(answers: GetAnswerResponse[], meta: PagableMeta) {
         this.answers = answers;
+        this.meta = meta;
     }
 }


### PR DESCRIPTION
## Summary
<!-- 작업한 내용을 간단히 작성해주세요. -->
답변 목록 조회 시 페이지네이션 메타 정보 반환 추가


## Description
<!-- 작업한 내용을 자세히 작성해주세요. : 변경된 코드 등 -->

- 답변 목록 조회 시 페이지네이션 메타 정보 반환 추가
````
{
  "status": 200,
  "message": "답변 내역을 조회했습니다.",
  "data": {
    "answers": [
      {
        "question": "", // 질문 내용
        "answer": "대답", // 대답 내용
        "user": {
          "userName": "조하나", // 유저 이름
          "userYear": 7, // 유저 기수
        },
      },
      ...
    ],
    "meta": {
      "totalItems": 27, // 전체 항목 개수
      "itemCount": 10, // 현재 페이지에 포함된 항목 개수
      "itemsPerPage": 10, // 페이지 당 항목 개수 (limit)
      "totalPages": 3, // 총 페이지 수
      "currentPage": 1, // 현재 페이지 번호
    },
  }
}
