### PR TITLE
set: 클라이언트용 userId 해시 적용

### DIFF
--- a/prisma/migrations/20241221163140_hashed_user_id/migration.sql
+++ b/prisma/migrations/20241221163140_hashed_user_id/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[hashedUserId]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `hashedUserId` to the `User` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- Activate pgcrypto extension to use gen_random_uuid
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- Add hashedUserId column with default value
+ALTER TABLE "User" ADD COLUMN "hashedUserId" UUID DEFAULT gen_random_uuid() NOT NULL;
+
+-- Create unique index for hashedUserId
+CREATE UNIQUE INDEX "User_hashedUserId_key" ON "User"("hashedUserId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,10 +8,11 @@ datasource db {
 }
 
 model User {
-  userId    Int      @id @default(autoincrement())
-  userName  String   @db.VarChar(20)
-  userYear  Int
-  createdAt DateTime @default(now())
+  userId       Int      @id @default(autoincrement())
+  hashedUserId String   @unique @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  userName     String   @db.VarChar(20)
+  userYear     Int
+  createdAt    DateTime @default(now())
 
   calendars Calendar[]
 }

--- a/src/modules/calendar/calendar.controller.ts
+++ b/src/modules/calendar/calendar.controller.ts
@@ -76,7 +76,7 @@ export class CalendarController {
             '유저 별 캘린더 내용을 조회합니다. 출석한 날짜에 대한 데이터만 존재합니다.',
     })
     async getUserCalendar(
-        @Param('userId') userId: number,
+        @Param('userId') userId: string,
     ): Promise<ResultResponse<GetCalendarResponse[]>> {
         const userCalendar = await this.calendarService.getUserCalendar(userId);
         return new ResultResponse(

--- a/src/modules/calendar/dto/request/create.calendar.request.ts
+++ b/src/modules/calendar/dto/request/create.calendar.request.ts
@@ -5,11 +5,10 @@ import { Type } from 'class-transformer';
 export class CreateCalendarRequest {
     @ApiPropertyOptional({
         description: '유저 아이디',
-        example: 1,
+        example: 'hashedUserId',
     })
-    @Type(() => Number)
-    @IsNumber()
-    readonly userId: number;
+    @IsString()
+    readonly userId: string;
 
     @ApiPropertyOptional({
         description: '출석 날짜 (일자만 입력)',

--- a/src/modules/calendar/repository/calendar.repository.ts
+++ b/src/modules/calendar/repository/calendar.repository.ts
@@ -10,11 +10,20 @@ export class CalendarRepository {
 
     async createCalendar(
         request: CreateCalendarRequest,
+        userId: number,
         drawId: number | null,
     ): Promise<CalendarEntity> {
+        const {
+            calendarDate,
+            questionId,
+            calendarAnswer,
+        }: CreateCalendarRequest = request;
         return this.prisma.calendar.create({
             data: {
-                ...request,
+                userId,
+                calendarDate,
+                questionId,
+                calendarAnswer,
                 drawId,
             },
             include: {

--- a/src/modules/question/question.controller.ts
+++ b/src/modules/question/question.controller.ts
@@ -1,10 +1,4 @@
-import {
-    Controller,
-    Get,
-    HttpStatus,
-    Param,
-    ParseIntPipe,
-} from '@nestjs/common';
+import { Controller, Get, HttpStatus, Param } from '@nestjs/common';
 import { QuestionService } from './question.service';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { GetQuestionResponse } from './dto/response/get.question.response';
@@ -22,7 +16,7 @@ export class QuestionController {
             '랜덤으로 질문 하나를 조회합니다. 사용자가 입력하지 않은 질문 중 랜덤으로 한 개가 조회 됩니다.',
     })
     async getQuestion(
-        @Param('userId', ParseIntPipe) userId: number,
+        @Param('userId') userId: string,
     ): Promise<ResultResponse<GetQuestionResponse>> {
         const question = await this.questionService.getQuestion(userId);
         return new ResultResponse(

--- a/src/modules/question/question.service.ts
+++ b/src/modules/question/question.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common';
 import { QuestionRepository } from './repository/question.repository';
 import { GetQuestionResponse } from './dto/response/get.question.response';
 import { UserRepository } from '../user/repository/user.repository';
-import { NotFoundUserException } from '../../global/exception/custom.exception';
 
 @Injectable()
 export class QuestionService {
@@ -11,10 +10,9 @@ export class QuestionService {
         private readonly userRepository: UserRepository,
     ) {}
 
-    async getQuestion(userId: number): Promise<GetQuestionResponse> {
-        if (!(await this.userRepository.getUserById(userId))) {
-            throw new NotFoundUserException();
-        }
+    async getQuestion(hashedUserId: string): Promise<GetQuestionResponse> {
+        const userId =
+            await this.userRepository.getUserIdByHashedId(hashedUserId);
         const question = await this.questionRepository.getQuestion(userId);
         return new GetQuestionResponse(question);
     }

--- a/src/modules/user/dto/response/get.user.response.ts
+++ b/src/modules/user/dto/response/get.user.response.ts
@@ -1,12 +1,12 @@
 import { UserEntity } from '../../entities/user.entity';
 
 export class GetUserResponse {
-    readonly userId: number;
+    readonly userId: string;
     readonly userName: string;
     readonly userYear: number;
 
     constructor(userEntity: UserEntity) {
-        this.userId = userEntity.userId;
+        this.userId = userEntity.hashedUserId;
         this.userName = userEntity.userName;
         this.userYear = userEntity.userYear;
     }

--- a/src/modules/user/entities/user.entity.ts
+++ b/src/modules/user/entities/user.entity.ts
@@ -2,6 +2,7 @@ import { User } from '@prisma/client';
 
 export class UserEntity implements User {
     userId: number;
+    hashedUserId: string;
     userName: string;
     userYear: number;
     createdAt: Date;

--- a/src/modules/user/repository/user.repository.ts
+++ b/src/modules/user/repository/user.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { UserEntity } from '../entities/user.entity';
+import { NotFoundUserException } from '../../../global/exception/custom.exception';
 
 @Injectable()
 export class UserRepository {
@@ -20,7 +21,14 @@ export class UserRepository {
         });
     }
 
-    async getUserById(userId: number): Promise<UserEntity> {
-        return this.prisma.user.findUnique({ where: { userId } });
+    async getUserIdByHashedId(hashedUserId: string): Promise<number> {
+        const user = await this.prisma.user.findUnique({
+            where: { hashedUserId },
+            select: { userId: true },
+        });
+        if (!user) {
+            throw new NotFoundUserException();
+        }
+        return user.userId;
     }
 }


### PR DESCRIPTION
## Summary
<!-- 작업한 내용을 간단히 작성해주세요. -->
클라이언트용 userId 해시 적용


## Description
<!-- 작업한 내용을 자세히 작성해주세요. : 변경된 코드 등 -->

- 클라이언트용 userId 해시 적용
  - uuid 사용해서 생성
    - postgresql 내부에서 자동 생성되도록 구현
  - 서버 내부 로직에서는 기존 number userId 사용
    - request/response에서만 hashedUserId 사용